### PR TITLE
Accept a funcref for info

### DIFF
--- a/autoload/popsikey.vim
+++ b/autoload/popsikey.vim
@@ -94,7 +94,7 @@ function s:do_popup(id) abort
   const l:group = g:popsikey[s:popsikey_id]
   const l:choices =
         \ deepcopy(l:group.maps)
-        \ ->map({i,v -> printf("%s\t%s", v.key, v.info)})
+        \ ->map({i,v -> printf("%s\t%s", v.key, type(v.info) == v:t_func ? call(v.info, []) : v.info )})
   highlight link PopupSelected Search
   const l:opts = extend(#{
         \ filter: 'popsikey#filter',

--- a/doc/popsikey.txt
+++ b/doc/popsikey.txt
@@ -58,7 +58,8 @@ popsikey#register({prefix}, {maps}, {opts})
                     - `key`: the key on which to trigger the mapping (without
                       the prefix)
                     - `info`: a short description of the action for this
-                      mapping
+                      mapping; this can be a |Funcref| returning a string for
+                      dynamic descriptions.
                     - `action`: the action to take (|popsikey-action|)
                     - `flags`: a string of |feedkeys()| flags. If `flags`
                       would cause keys not be mapped by |feedkeys()| and
@@ -79,8 +80,8 @@ popsikey#register({prefix}, {maps}, {opts})
                     \ col: 'cursor',
                     \ }
 <
-		*Error	do not override filter or callback
-                Doing so will break the menu's key-hanlder
+		WARNING: do not override filter or callback; doing so will
+		break the menu's key-handler.
 
                 Without |+popupwin|, `opts` is ignored.
 


### PR DESCRIPTION
This allows printing the current value for toggle options; for example:

	def Toggle(opt: string): string
		return printf('setl %s%s', (eval('&l:' .. opt) ? 'no' : ''), opt)
	enddef
	call popsikey#register('<Leader>t', [
		{key: 'l', flags: 'n', info: () => Toggle('list'),         action: ":setl list!\<CR>"},
		{key: 'c', flags: 'n', info: () => Toggle('cursorcolumn'), action: ":setl cursorcolumn!\<CR>"},
		{key: 'C', flags: 'n', info: () => Toggle('cursorline'),   action: ":setl cursorline!\<CR>"},
		{key: 's', flags: 'n', info: () => Toggle('shiftround'),   action: ":setl shiftround!\<CR>"},
		{key: 'w', flags: 'n', info: () => Toggle('wrap'),         action: ":setl wrap!\<CR>"},
	], {title:   '', padding: [0, 0, 0, 0], border:  [0, 0, 0, 0]})

Then on \<Leader>t I have "setl list", and if I select it and press \<Leader>t again I have "setl nolist".